### PR TITLE
Enable AddressSanitizer only for C and C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,11 @@ option( BUILD_SHARED_LIBS "Build hipSOLVER as a shared library" ON )
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 
 if(BUILD_ADDRESS_SANITIZER)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -shared-libasan")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -shared-libasan")
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-fsanitize=address>)
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-shared-libasan>)
+  add_link_options($<$<LINK_LANGUAGE:C,CXX>:-fuse-ld=lld>)
+  add_link_options($<$<LINK_LANGUAGE:C,CXX>:-fsanitize=address>)
+  add_link_options($<$<LINK_LANGUAGE:C,CXX>:-shared-libasan>)
 endif()
 
 if( CMAKE_BUILD_TYPE STREQUAL "Debug" )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -34,10 +34,6 @@ set (hipsolver_f90_source
 # Create hipSOLVER Fortran module
 add_library(hipsolver_fortran ${hipsolver_f90_source})
 
-if(BUILD_ADDRESS_SANITIZER)
-  add_link_options(-fuse-ld=lld)
-endif()
-
 add_library( hipsolver
   ${hipsolver_source}
   ${relative_hipsolver_headers_public}


### PR DESCRIPTION
As mentioned in https://github.com/ROCmSoftwarePlatform/hipSOLVER/pull/30, this change has a few minor benefits. It avoids the use of the flags variables so that we don't get warnings from rocm-cmake, and it conditionally enables the flags based on the target language, so Fortran targets are excluded no matter where they're declared relative to these flags.